### PR TITLE
Fix bug where fd's are not being cleaned up properly when releasing attached shm.

### DIFF
--- a/module.js
+++ b/module.js
@@ -1,4 +1,5 @@
 const cp = require('child_process');
+const fs = require('fs');
 
 const mmap = require('mmap-io');
 
@@ -8,6 +9,7 @@ let s_prefix = '/lw';
 let i_key = Math.floor(Math.random()*1e12);
 
 const h_creates = {};
+const h_attach = {};
 
 const self = module.exports = {
 	create(nb_buffer) {
@@ -20,21 +22,27 @@ const self = module.exports = {
 
 	read(s_key, nb_buffer) {
 		// console.log('recovering read sector from '+s_key+' @'+nb_buffer);
-		let i_fd = shm.open(s_key, shm.O_RDONLY, 0o666);
+	        let i_fd = shm.open(s_key, shm.O_RDONLY, 0o666);
+                h_attach[s_key] = i_fd;
 		return mmap.map(nb_buffer, mmap.PROT_READ, mmap.MAP_SHARED, i_fd);
 	},
 
 	read_write(s_key, nb_buffer) {
 		// console.log('recovering read/write sector from '+s_key+' @'+nb_buffer);
 		let i_fd = shm.open(s_key, shm.O_RDWR, 0o666);
+                h_attach[s_key] = i_fd;
 		return mmap.map(nb_buffer, mmap.PROT_READ | mmap.PROT_WRITE, mmap.MAP_SHARED, i_fd);
 	},
 
 	release(s_key) {
 		if(h_creates[s_key]) {
 			shm.unlink(s_key);
+                        fs.close(h_creates[s_key]);
 			delete h_creates[s_key];
-		}
+		} else if (h_attach[s_key]) {
+                        fs.close(h_attach[s_key]);
+			delete h_attach[s_key];
+                }
 	},
 
 	transfer(dsb) {
@@ -52,6 +60,9 @@ const self = module.exports = {
 
 process.on('exit', () => {
 	for(let s_key in h_creates) {
+		self.release(s_key);
+	}
+	for(let s_key in h_attach) {
 		self.release(s_key);
 	}
 });

--- a/module.js
+++ b/module.js
@@ -37,10 +37,10 @@ const self = module.exports = {
 	release(s_key) {
 		if(h_creates[s_key]) {
 			shm.unlink(s_key);
-                        fs.close(h_creates[s_key]);
+                        fs.closeSync(h_creates[s_key]);
 			delete h_creates[s_key];
 		} else if (h_attach[s_key]) {
-                        fs.close(h_attach[s_key]);
+                        fs.closeSync(h_attach[s_key]);
 			delete h_attach[s_key];
                 }
 	},

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "mmap"
     ],
     "license": "MIT",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "main": "module.js",
     "repository": {
         "type": "git",


### PR DESCRIPTION
I have an application that attaches and re-attaches to shm and it was running out of fd's after a while. The hack to track shm area simply attached and then clean them up when releasing them fixes that.